### PR TITLE
fix: Rewrite imports to remove Go modules refs

### DIFF
--- a/systemd.go
+++ b/systemd.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 
 	systemdDbus "github.com/coreos/go-systemd/dbus"
-	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 

--- a/systemd.go
+++ b/systemd.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"sync"
 
-	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
+	systemdDbus "github.com/coreos/go-systemd/dbus"
 	"github.com/godbus/dbus/v5"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )

--- a/v2/manager.go
+++ b/v2/manager.go
@@ -37,7 +37,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
+	systemdDbus "github.com/coreos/go-systemd/dbus"
 )
 
 const (

--- a/v2/manager.go
+++ b/v2/manager.go
@@ -32,7 +32,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/containerd/cgroups/v2/stats"
-	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"

--- a/v2/utils.go
+++ b/v2/utils.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus"
 
 	"github.com/containerd/cgroups/v2/stats"
 	"github.com/opencontainers/runtime-spec/specs-go"


### PR DESCRIPTION
Rewriting the imports to remove Go modules refs removes the required use of Go modules to import this repo with `dep` in the `capsule8/c8` repo.